### PR TITLE
#RICT-1527 Linter target should be called before build

### DIFF
--- a/ViewGenerator/ViewGenerator.nuspec
+++ b/ViewGenerator/ViewGenerator.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>ViewGenerator</id>
-    <version>1.0.122</version>
+    <version>1.0.123</version>
     <authors>jmn</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <developmentDependency>true</developmentDependency>
@@ -11,7 +11,7 @@
       <dependency id="ViewGeneratorCore" version="1.0.116" />
       <dependency id="Microsoft.TypeScript.MSBuild" version="3.3.1" />
       <dependency id="Delegate.SassBuilder" version="1.4.0" />
-      <dependency id="OutSystems.ESLint.MSBuild" version="1.0.3" />
+      <dependency id="OutSystems.ESLint.MSBuild" version="1.0.4" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
Rational behind this change: currently we have the linter target after build, so I've changed the linter target to be called before build so that errors are always shown (e.g. if you have an (unsuccessful) build and then you build the solution again right after the (unsuccessful) build without doing any changes, the build passes).