### PR TITLE
Design-time builds was the problem

### DIFF
--- a/ViewGeneratorCore/build/ViewGeneratorCore.targets
+++ b/ViewGeneratorCore/build/ViewGeneratorCore.targets
@@ -40,7 +40,7 @@
     </PropertyGroup>
   </Target>
   
-  <Target Name="VGC_GenerateView" BeforeTargets="TransformDuringBuild;PrepareForBuild;CoreCompile" DependsOnTargets="VGC_SetVariables;VGC_CleanGenerated">
+  <Target Name="VGC_GenerateView" Condition="$(DesignTimeBuild) != true And $(BuildingProject) == true" BeforeTargets="TransformDuringBuild;PrepareForBuild;CoreCompile" DependsOnTargets="VGC_SetVariables;VGC_CleanGenerated">
     <Message Importance="Normal" Text="Generating View files" />
     <Exec Command="&quot;$(ViewGeneratorCoreNodeJsExe)&quot; &quot;$(MSBuildThisFileDirectory)..\tools\node_modules\@outsystems\ts2lang\ts2lang-main.js&quot; -f &quot;$(MSBuildProjectDirectory)\ts2lang.json&quot; -t &quot;$(MSBuildThisFileDirectory)..\tools\ViewGenerator.js&quot;" />
   </Target>


### PR DESCRIPTION
Using the CSProj format Sdk="Microsoft.NET.Sdk", some custom targets are built at design-time. This results in generated files being infinitely generated. This commit solves the issue.

Following this [link](https://github.com/dotnet/project-system/blob/master/docs/design-time-builds.md) and using Microsoft's tool, I checked that during design-time these targets are constantly being built, what caused our custom target to re-build every time (see image).

![Untitled](https://user-images.githubusercontent.com/22914881/64607255-1457f100-d3c0-11e9-8654-16e440f61f6f.png)


Initially I was having this problem when converting ScreenTemplates. Tested with the other projects using ViewGeneratorCore's modified targets file and everything builds like before, with or without the new format 