### PR TITLE
Small improvements to packages deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,9 @@ ViewPacker/tools/node_modules/
 !ReactViewResources/AMDLoader/AMDLoaderExports.js
 Example/.wpcache/
 Example/global.d.ts
-ReactViewControl/tools/
-ReactViewResources/tools/
-WebViewControl/tools/
+ReactViewControl/cake_tools/
+ReactViewResources/cake_tools/
+WebViewControl/cake_tools/
+ViewGenerator/cake_tools/
 ViewGeneratorCore/cake_tools/
+ViewPacker/cake_tools/

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ ViewPacker/tools/node_modules/
 !ReactViewResources/AMDLoader/AMDLoaderExports.js
 Example/.wpcache/
 Example/global.d.ts
+ReactViewControl/tools/
+ReactViewResources/tools/
+WebViewControl/tools/
+ViewGeneratorCore/cake_tools/

--- a/ReactViewControl/build.cake
+++ b/ReactViewControl/build.cake
@@ -64,9 +64,10 @@ var build = Task("Build")
     .Does(()=>
     {
         Information("Starting Build");
-        MSBuild(solutionPath, settings =>
-            settings.SetConfiguration(configuration)
-        );
+        MSBuild(solutionPath, settings => {
+            settings.WithTarget("Rebuild");
+            settings.SetConfiguration(configuration);
+        });
         Information("Ending Build");
     });
 

--- a/ReactViewControl/build.ps1
+++ b/ReactViewControl/build.ps1
@@ -113,7 +113,7 @@ if(!$PSScriptRoot){
     $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
 }
 
-$TOOLS_DIR = Join-Path $PSScriptRoot "tools"
+$TOOLS_DIR = Join-Path $PSScriptRoot "cake_tools"
 $ADDINS_DIR = Join-Path $TOOLS_DIR "Addins"
 $MODULES_DIR = Join-Path $TOOLS_DIR "Modules"
 $NUGET_EXE = Join-Path $TOOLS_DIR "nuget.exe"
@@ -123,6 +123,10 @@ $PACKAGES_CONFIG = Join-Path $TOOLS_DIR "packages.config"
 $PACKAGES_CONFIG_MD5 = Join-Path $TOOLS_DIR "packages.config.md5sum"
 $ADDINS_PACKAGES_CONFIG = Join-Path $ADDINS_DIR "packages.config"
 $MODULES_PACKAGES_CONFIG = Join-Path $MODULES_DIR "packages.config"
+
+$env:CAKE_PATHS_TOOLS = $TOOLS_DIR
+$env:CAKE_PATHS_ADDINS = $ADDINS_DIR
+$env:MODULES_DIR = $MODULES_DIR
 
 # Make sure tools folder exists
 if ((Test-Path $PSScriptRoot) -and !(Test-Path $TOOLS_DIR)) {

--- a/ReactViewResources/build.cake
+++ b/ReactViewResources/build.cake
@@ -64,9 +64,10 @@ var build = Task("Build")
     .Does(()=>
     {
         Information("Starting Build");
-        MSBuild(solutionPath, settings =>
-            settings.SetConfiguration(configuration)
-        );
+        MSBuild(solutionPath, settings => {
+            settings.WithTarget("Rebuild");
+            settings.SetConfiguration(configuration);
+        });
         Information("Ending Build");
     });
 

--- a/ReactViewResources/build.ps1
+++ b/ReactViewResources/build.ps1
@@ -112,7 +112,7 @@ if(!$PSScriptRoot){
     $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
 }
 
-$TOOLS_DIR = Join-Path $PSScriptRoot "tools"
+$TOOLS_DIR = Join-Path $PSScriptRoot "cake_tools"
 $ADDINS_DIR = Join-Path $TOOLS_DIR "Addins"
 $MODULES_DIR = Join-Path $TOOLS_DIR "Modules"
 $NUGET_EXE = Join-Path $TOOLS_DIR "nuget.exe"
@@ -122,6 +122,10 @@ $PACKAGES_CONFIG = Join-Path $TOOLS_DIR "packages.config"
 $PACKAGES_CONFIG_MD5 = Join-Path $TOOLS_DIR "packages.config.md5sum"
 $ADDINS_PACKAGES_CONFIG = Join-Path $ADDINS_DIR "packages.config"
 $MODULES_PACKAGES_CONFIG = Join-Path $MODULES_DIR "packages.config"
+
+$env:CAKE_PATHS_TOOLS = $TOOLS_DIR
+$env:CAKE_PATHS_ADDINS = $ADDINS_DIR
+$env:MODULES_DIR = $MODULES_DIR
 
 # Make sure tools folder exists
 if ((Test-Path $PSScriptRoot) -and !(Test-Path $TOOLS_DIR)) {

--- a/ReactViewResources/config.json
+++ b/ReactViewResources/config.json
@@ -1,5 +1,6 @@
 {
 	"slnFilePath": "../WebView.sln",
+	"csprojFilePath": "./ReactViewResources.csproj",
 	"configuration": "Release",
 	"testsdllFilePath": "../Release/Tests.dll",
 	"nuspecFilePath": "ReactViewResources.nuspec",

--- a/ViewGenerator/build.cake
+++ b/ViewGenerator/build.cake
@@ -64,9 +64,10 @@ var build = Task("Build")
     .Does(()=>
     {
         Information("Starting Build");
-        MSBuild(solutionPath, settings =>
-            settings.SetConfiguration(configuration)
-        );
+        MSBuild(csprojFilePath, settings => {
+            settings.WithTarget("Rebuild");
+            settings.SetConfiguration(configuration);
+        });
         Information("Ending Build");
     });
 

--- a/ViewGenerator/build.ps1
+++ b/ViewGenerator/build.ps1
@@ -111,7 +111,7 @@ if(!$PSScriptRoot){
     $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
 }
 
-$TOOLS_DIR = Join-Path $PSScriptRoot "tools"
+$TOOLS_DIR = Join-Path $PSScriptRoot "cake_tools"
 $ADDINS_DIR = Join-Path $TOOLS_DIR "Addins"
 $MODULES_DIR = Join-Path $TOOLS_DIR "Modules"
 $NUGET_EXE = Join-Path $TOOLS_DIR "nuget.exe"
@@ -121,6 +121,10 @@ $PACKAGES_CONFIG = Join-Path $TOOLS_DIR "packages.config"
 $PACKAGES_CONFIG_MD5 = Join-Path $TOOLS_DIR "packages.config.md5sum"
 $ADDINS_PACKAGES_CONFIG = Join-Path $ADDINS_DIR "packages.config"
 $MODULES_PACKAGES_CONFIG = Join-Path $MODULES_DIR "packages.config"
+
+$env:CAKE_PATHS_TOOLS = $TOOLS_DIR
+$env:CAKE_PATHS_ADDINS = $ADDINS_DIR
+$env:MODULES_DIR = $MODULES_DIR 
 
 # Make sure tools folder exists
 if ((Test-Path $PSScriptRoot) -and !(Test-Path $TOOLS_DIR)) {

--- a/ViewGenerator/config.json
+++ b/ViewGenerator/config.json
@@ -1,7 +1,7 @@
 {
 	"slnFilePath": "../WebView.sln",
+	"csprojFilePath": "./ViewGenerator.csproj",
 	"configuration": "Release",
-	"testsdllFilePath": "../Release/Tests.dll",
 	"nuspecFilePath": "ViewGenerator.nuspec",
 	"packageRootPath":"../"
 }

--- a/ViewGeneratorCore/build.cake
+++ b/ViewGeneratorCore/build.cake
@@ -63,9 +63,10 @@ var build = Task("Build")
     .Does(()=>
     {
         Information("Starting Build");
-        MSBuild(solutionPath, settings =>
-            settings.SetConfiguration(configuration)
-        );
+        MSBuild(solutionPath, settings => {
+            settings.WithTarget("Rebuild");
+            settings.SetConfiguration(configuration);
+        });
         Information("Ending Build");
     });
 

--- a/ViewGeneratorCore/build.cake
+++ b/ViewGeneratorCore/build.cake
@@ -63,7 +63,7 @@ var build = Task("Build")
     .Does(()=>
     {
         Information("Starting Build");
-        MSBuild(solutionPath, settings => {
+        MSBuild(csprojFilePath, settings => {
             settings.WithTarget("Rebuild");
             settings.SetConfiguration(configuration);
         });

--- a/ViewGeneratorCore/build.ps1
+++ b/ViewGeneratorCore/build.ps1
@@ -112,7 +112,7 @@ if(!$PSScriptRoot){
     $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
 }
 
-$TOOLS_DIR = Join-Path $PSScriptRoot "tools"
+$TOOLS_DIR = Join-Path $PSScriptRoot "cake_tools"
 $ADDINS_DIR = Join-Path $TOOLS_DIR "Addins"
 $MODULES_DIR = Join-Path $TOOLS_DIR "Modules"
 $NUGET_EXE = Join-Path $TOOLS_DIR "nuget.exe"
@@ -122,6 +122,10 @@ $PACKAGES_CONFIG = Join-Path $TOOLS_DIR "packages.config"
 $PACKAGES_CONFIG_MD5 = Join-Path $TOOLS_DIR "packages.config.md5sum"
 $ADDINS_PACKAGES_CONFIG = Join-Path $ADDINS_DIR "packages.config"
 $MODULES_PACKAGES_CONFIG = Join-Path $MODULES_DIR "packages.config"
+
+$env:CAKE_PATHS_TOOLS = $TOOLS_DIR
+$env:CAKE_PATHS_ADDINS = $ADDINS_DIR
+$env:MODULES_DIR = $MODULES_DIR 
 
 # Make sure tools folder exists
 if ((Test-Path $PSScriptRoot) -and !(Test-Path $TOOLS_DIR)) {

--- a/ViewGeneratorCore/config.json
+++ b/ViewGeneratorCore/config.json
@@ -1,7 +1,7 @@
 {
+	"slnFilePath": "../WebView.sln",
 	"csprojFilePath": "./ViewGeneratorCore.csproj",
 	"configuration": "Release",
-	"testsdllFilePath": "../Release/Tests.dll",
 	"nuspecFilePath": "ViewGeneratorCore.nuspec",
 	"packageRootPath":"../"
 }

--- a/ViewGeneratorCore/config.json
+++ b/ViewGeneratorCore/config.json
@@ -1,5 +1,5 @@
 {
-	"slnFilePath": "../WebView.sln",
+	"csprojFilePath": "./ViewGeneratorCore.csproj",
 	"configuration": "Release",
 	"testsdllFilePath": "../Release/Tests.dll",
 	"nuspecFilePath": "ViewGeneratorCore.nuspec",

--- a/ViewPacker/build.cake
+++ b/ViewPacker/build.cake
@@ -63,9 +63,10 @@ var build = Task("Build")
     .Does(()=>
     {
         Information("Starting Build");
-        MSBuild(solutionPath, settings =>
-            settings.SetConfiguration(configuration)
-        );
+        MSBuild(csprojFilePath, settings => {
+            settings.WithTarget("Rebuild");
+            settings.SetConfiguration(configuration);
+        });
         Information("Ending Build");
     });
 

--- a/ViewPacker/build.ps1
+++ b/ViewPacker/build.ps1
@@ -112,7 +112,7 @@ if(!$PSScriptRoot){
     $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
 }
 
-$TOOLS_DIR = Join-Path $PSScriptRoot "tools"
+$TOOLS_DIR = Join-Path $PSScriptRoot "cake_tools"
 $ADDINS_DIR = Join-Path $TOOLS_DIR "Addins"
 $MODULES_DIR = Join-Path $TOOLS_DIR "Modules"
 $NUGET_EXE = Join-Path $TOOLS_DIR "nuget.exe"
@@ -122,6 +122,10 @@ $PACKAGES_CONFIG = Join-Path $TOOLS_DIR "packages.config"
 $PACKAGES_CONFIG_MD5 = Join-Path $TOOLS_DIR "packages.config.md5sum"
 $ADDINS_PACKAGES_CONFIG = Join-Path $ADDINS_DIR "packages.config"
 $MODULES_PACKAGES_CONFIG = Join-Path $MODULES_DIR "packages.config"
+
+$env:CAKE_PATHS_TOOLS = $TOOLS_DIR
+$env:CAKE_PATHS_ADDINS = $ADDINS_DIR
+$env:MODULES_DIR = $MODULES_DIR
 
 # Make sure tools folder exists
 if ((Test-Path $PSScriptRoot) -and !(Test-Path $TOOLS_DIR)) {

--- a/ViewPacker/config.json
+++ b/ViewPacker/config.json
@@ -1,7 +1,7 @@
 {
 	"slnFilePath": "../WebView.sln",
+	"csprojFilePath": "./ViewPacker.csproj",
 	"configuration": "Release",
-	"testsdllFilePath": "../Release/Tests.dll",
 	"nuspecFilePath": "ViewPacker.nuspec",
 	"packageRootPath":"../"
 }

--- a/WebViewControl/build.cake
+++ b/WebViewControl/build.cake
@@ -64,9 +64,10 @@ var build = Task("Build")
     .Does(()=>
     {
         Information("Starting Build");
-        MSBuild(solutionPath, settings =>
-            settings.SetConfiguration(configuration)
-        );
+        MSBuild(solutionPath, settings => {
+            settings.WithTarget("Rebuild");
+            settings.SetConfiguration(configuration);
+        });
         Information("Ending Build");
     });
 

--- a/WebViewControl/build.ps1
+++ b/WebViewControl/build.ps1
@@ -111,7 +111,7 @@ if(!$PSScriptRoot){
     $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
 }
 
-$TOOLS_DIR = Join-Path $PSScriptRoot "tools"
+$TOOLS_DIR = Join-Path $PSScriptRoot "cake_tools"
 $ADDINS_DIR = Join-Path $TOOLS_DIR "Addins"
 $MODULES_DIR = Join-Path $TOOLS_DIR "Modules"
 $NUGET_EXE = Join-Path $TOOLS_DIR "nuget.exe"
@@ -121,6 +121,10 @@ $PACKAGES_CONFIG = Join-Path $TOOLS_DIR "packages.config"
 $PACKAGES_CONFIG_MD5 = Join-Path $TOOLS_DIR "packages.config.md5sum"
 $ADDINS_PACKAGES_CONFIG = Join-Path $ADDINS_DIR "packages.config"
 $MODULES_PACKAGES_CONFIG = Join-Path $MODULES_DIR "packages.config"
+
+$env:CAKE_PATHS_TOOLS = $TOOLS_DIR
+$env:CAKE_PATHS_ADDINS = $ADDINS_DIR
+$env:MODULES_DIR = $MODULES_DIR
 
 # Make sure tools folder exists
 if ((Test-Path $PSScriptRoot) -and !(Test-Path $TOOLS_DIR)) {

--- a/WebViewControl/config.json
+++ b/WebViewControl/config.json
@@ -1,5 +1,6 @@
 {
 	"slnFilePath": "../WebView.sln",
+	"csprojFilePath": "./WebViewControl.csproj",
 	"configuration": "Release",
 	"testsdllFilePath": "../Release/Tests.dll",
 	"nuspecFilePath": "WebViewControl.nuspec",


### PR DESCRIPTION
- Fixed ViewGenerator and ViewPacker deployment (failing due to clashing with "tools" folder inside projects).
- Removed ViewGenerator, ViewGeneratorCore, and ViewPacker dependency to tests since these projects do not have tests.
- Fixed build of ViewGenerator, ViewGeneratorCore, and ViewPacker projects (skipped when building whole solution).