### PR TITLE
Fixed CefGlue charset encoding

### DIFF
--- a/WebViewControl/AsyncResourceHandler.cs
+++ b/WebViewControl/AsyncResourceHandler.cs
@@ -19,7 +19,7 @@ namespace WebViewControl {
         }
 
         public void SetResponse(string response, string mimeType = null) {
-            Response = GetMemoryStream(response, Encoding.UTF8, false);
+            Response = GetMemoryStream(response, Encoding.UTF8, includePreamble: true);
             MimeType = mimeType;
         }
 

--- a/WebViewControl/WebView.cs
+++ b/WebViewControl/WebView.cs
@@ -170,10 +170,6 @@ namespace WebViewControl {
             InitializeCef();
 
             chromium = new ChromiumBrowser();
-
-            // By default, charset encoding is ISO-8859-1, which does not work properly with a few special characters
-            chromium.Settings.DefaultEncoding = Encoding.UTF8.WebName;
-
             chromium.BrowserInitialized += OnWebViewBrowserInitialized;
             chromium.LoadEnd += OnWebViewLoadEnd;
             chromium.LoadError += OnWebViewLoadError;

--- a/WebViewControl/WebView.cs
+++ b/WebViewControl/WebView.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Xilium.CefGlue;
@@ -169,6 +170,10 @@ namespace WebViewControl {
             InitializeCef();
 
             chromium = new ChromiumBrowser();
+
+            // By default, charset encoding is ISO-8859-1, which does not work properly with a few special characters
+            chromium.Settings.DefaultEncoding = Encoding.UTF8.WebName;
+
             chromium.BrowserInitialized += OnWebViewBrowserInitialized;
             chromium.LoadEnd += OnWebViewLoadEnd;
             chromium.LoadError += OnWebViewLoadError;

--- a/WebViewControl/WebView.cs
+++ b/WebViewControl/WebView.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Xilium.CefGlue;

--- a/WebViewControl/WebViewControl.csproj
+++ b/WebViewControl/WebViewControl.csproj
@@ -11,7 +11,7 @@
     <Product>WebViewControl</Product>
     <Copyright>Copyright ©  2019</Copyright>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>2.75.13</Version>
+    <Version>2.75.14</Version>
     <PackageId>WebViewControl-WPF</PackageId>
     <Authors>OutSystems</Authors>
     <PackageOutputPath>$(MSBuildProjectDirectory)\..\nuget</PackageOutputPath>


### PR DESCRIPTION
- I've changed browser default encoding and tested on Service Studio, did not notice any impacts on web views (Styles Editor, Web Editor, DataSet editors, etc.)
- This fixes strange characters appearing after some icons (FontAwesome specifically).