### PR TITLE
Fix mklink build errors

### DIFF
--- a/ViewGenerator/ViewGenerator.nuspec
+++ b/ViewGenerator/ViewGenerator.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>ViewGenerator</id>
-    <version>1.0.248</version>
+    <version>1.0.249</version>
     <authors>jmn</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <developmentDependency>true</developmentDependency>

--- a/ViewGenerator/build/ViewGenerator.targets
+++ b/ViewGenerator/build/ViewGenerator.targets
@@ -42,8 +42,8 @@
     </PropertyGroup>
   </Target>
 
-  <Target Name="VG_LinkNodeModules" Condition="'$(PluginsRelativePath)' != '' AND !Exists('$(ProjectDir)node_modules\webview.plugins')" >
-    <Exec Command="mklink /J &quot;$(ProjectDir)node_modules\webview.plugins&quot; &quot;$(ProjectDir)$(PluginsRelativePath)node_modules&quot;" />
+  <Target Name="VG_LinkNodeModules" Condition="'$(PluginsRelativePath)' != ''" >
+    <Exec Condition="!Exists('$(ProjectDir)node_modules\webview.plugins')" Command="mklink /J &quot;$(ProjectDir)node_modules\webview.plugins&quot; &quot;$(ProjectDir)$(PluginsRelativePath)node_modules&quot;" />
   </Target>
 
   <Target Name="VG_UnlinkNodeModules" Condition="Exists('$(ProjectDir)node_modules\webview.plugins')">


### PR DESCRIPTION
Context about this change: there's some intermittent build errors due to parallel builds on net472 and netstandard2.0 in projects using ViewGenerator. This fix prevents that from happening (or at least making it a very remote possibility).