### PR TITLE
Remote debugging port is now parametrized via environment variable

### DIFF
--- a/WebViewControl.Avalonia/WebViewControl.Avalonia.csproj
+++ b/WebViewControl.Avalonia/WebViewControl.Avalonia.csproj
@@ -12,7 +12,7 @@
     <Product>WebViewControl</Product>
     <Copyright>Copyright ©  2019</Copyright>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>2.85.25</Version>
+    <Version>2.85.26</Version>
     <PackageId>WebViewControl-Avalonia</PackageId>
     <Authors>OutSystems</Authors>
     <PackageProjectUrl>https://github.com/OutSystems/WebView</PackageProjectUrl>

--- a/WebViewControl.Avalonia/WebViewControl.Avalonia.csproj
+++ b/WebViewControl.Avalonia/WebViewControl.Avalonia.csproj
@@ -73,10 +73,4 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>
-
-  <ItemGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseAvaloniaRemoteDebugSupport|AnyCPU'">
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.8" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
-  </ItemGroup>
-
 </Project>

--- a/WebViewControl/GlobalSettings.cs
+++ b/WebViewControl/GlobalSettings.cs
@@ -1,7 +1,4 @@
-﻿#if REMOTE_DEBUG_SUPPORT
-using Microsoft.Extensions.Configuration;
-#endif
-using System;
+﻿using System;
 using System.IO;
 using Xilium.CefGlue.Common;
 
@@ -72,10 +69,7 @@ namespace WebViewControl {
 
         internal int GetRemoteDebuggingPort() {
 #if REMOTE_DEBUG_SUPPORT
-            var configurationBuilder = new ConfigurationBuilder();
-            configurationBuilder.AddJsonFile("appsettings.json", optional: true, reloadOnChange: false);
-            var configuration = configurationBuilder.Build();
-            var port = configuration["RemoteDebuggingPort"];
+            var port = Environment.GetEnvironmentVariable("WEBVIEW_REMOTE_DEBUGGING_PORT");
             int.TryParse(port != null ? port : "", out var result);
             return result;
 #else


### PR DESCRIPTION
Additional dependencies in the previous approach (JSON config file) were creating problems with dependencies at runtime.