### PR TITLE
Pack XML documentation for public elements

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -273,3 +273,11 @@ dotnet_naming_symbols.parameters_group.applicable_kinds = parameter
 dotnet_naming_rule.parameters_rule.symbols              = parameters_group
 dotnet_naming_rule.parameters_rule.style                = camel_case_style
 dotnet_naming_rule.parameters_rule.severity             = suggestion
+
+# suppress warnings about missing documentation for public elements
+# (hopefully one day we can turn these off)
+# missing on public element
+dotnet_diagnostic.CS1591.severity = none
+# missing parameter doc
+dotnet_diagnostic.CS1573.severity = none
+

--- a/WebViewControl.Avalonia/WebViewControl.Avalonia.csproj
+++ b/WebViewControl.Avalonia/WebViewControl.Avalonia.csproj
@@ -12,6 +12,7 @@
     <Product>WebViewControl</Product>
     <Copyright>Copyright ©  2019</Copyright>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Version>2.85.36</Version>
     <PackageId>WebViewControl-Avalonia</PackageId>
     <Authors>OutSystems</Authors>

--- a/WebViewControl/WebView.cs
+++ b/WebViewControl/WebView.cs
@@ -97,7 +97,7 @@ namespace WebViewControl {
        
         public WebView() : this(false) { }
 
-        /// <param name="useSharedDomain">Shared domains means that the webview default domain will always be the same. When <see cref="useSharedDomain"/> is false a
+        /// <param name="useSharedDomain">Shared domains means that the webview default domain will always be the same. When <paramref ref="useSharedDomain"/> is false a
         /// unique domain is used for every webview.</param>
         internal WebView(bool useSharedDomain) {
             if (IsInDesignMode) {
@@ -228,7 +228,7 @@ namespace WebViewControl {
 
         /// <summary>
         /// Specifies the maximium number of calls that can be made simultaneously to native
-        //  object methods. Defaults to the int.MaxValue.
+        /// object methods. Defaults to the int.MaxValue.
         /// </summary>
         internal int MaxNativeMethodsParallelCalls {
             get => chromium.MaxNativeMethodsParallelCalls;

--- a/WebViewControl/WebViewControl.csproj
+++ b/WebViewControl/WebViewControl.csproj
@@ -11,6 +11,7 @@
     <Product>WebViewControl</Product>
     <Copyright>Copyright ©  2019</Copyright>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Version>2.85.28</Version>
     <PackageId>WebViewControl-WPF</PackageId>
     <Authors>OutSystems</Authors>


### PR DESCRIPTION
Without adding the XML doc files to the nuget package, the information
isn't usable in IDE tooltips or when checking class metadata and
signature information, which is bad for the developer experience.

This commit adds the XML docs, fixes a few malformed comments and
removes warnings for missing docs on public elements and parameters.