### PR TITLE
RDOIAT-481 - Fix tests pipelines blowup when WebView finalizer runs

### DIFF
--- a/WebViewControl.Avalonia/WebViewControl.Avalonia.csproj
+++ b/WebViewControl.Avalonia/WebViewControl.Avalonia.csproj
@@ -13,7 +13,7 @@
     <Copyright>Copyright ©  2019</Copyright>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>2.91.22</Version>
+    <Version>2.91.23</Version>
     <PackageId>WebViewControl-Avalonia</PackageId>
     <Authors>OutSystems</Authors>
     <PackageProjectUrl>https://github.com/OutSystems/WebView</PackageProjectUrl>

--- a/WebViewControl.Avalonia/WebViewControl.Avalonia.csproj
+++ b/WebViewControl.Avalonia/WebViewControl.Avalonia.csproj
@@ -13,7 +13,7 @@
     <Copyright>Copyright ©  2019</Copyright>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>2.91.21</Version>
+    <Version>2.91.22</Version>
     <PackageId>WebViewControl-Avalonia</PackageId>
     <Authors>OutSystems</Authors>
     <PackageProjectUrl>https://github.com/OutSystems/WebView</PackageProjectUrl>

--- a/WebViewControl/WebView.cs
+++ b/WebViewControl/WebView.cs
@@ -178,13 +178,11 @@ namespace WebViewControl {
             var disposed = false;
 
             void InternalDispose() {
-                lock (SyncRoot) {
-                    if (disposed) {
-                        return; // bail-out
-                    }
-
-                    disposed = true;
+                if (disposed) {
+                    return; // bail-out
                 }
+
+                disposed = true;
 
                 AsyncCancellationTokenSource?.Cancel();
 

--- a/WebViewControl/WebView.cs
+++ b/WebViewControl/WebView.cs
@@ -189,7 +189,7 @@ namespace WebViewControl {
                 }
 
                 AsyncCancellationTokenSource?.Cancel();
-                
+
                 WebViewInitialized = null;
                 BeforeNavigate = null;
                 BeforeResourceLoad = null;

--- a/WebViewControl/WebView.cs
+++ b/WebViewControl/WebView.cs
@@ -47,6 +47,7 @@ namespace WebViewControl {
         private string htmlToLoad;
         private volatile bool isDisposing;
         private IDisposable[] disposables;
+        private bool isDisposed;
 
         private CancellationTokenSource AsyncCancellationTokenSource { get; } = new CancellationTokenSource();
 
@@ -178,20 +179,17 @@ namespace WebViewControl {
                 GC.SuppressFinalize(this);
             }
 
-            var disposed = false;
-
             void InternalDispose() {
-                if (disposed) {
-                    return; // bail-out
+                lock (SyncRoot) {
+                    if (isDisposed) {
+                        return; // bail-out
+                    }
+
+                    isDisposed = true;
                 }
 
-                disposed = true;
-
-                try {
-                    AsyncCancellationTokenSource?.Cancel();
-                } catch (ObjectDisposedException) { }
+                AsyncCancellationTokenSource?.Cancel();
                 
-
                 WebViewInitialized = null;
                 BeforeNavigate = null;
                 BeforeResourceLoad = null;

--- a/WebViewControl/WebView.cs
+++ b/WebViewControl/WebView.cs
@@ -187,7 +187,10 @@ namespace WebViewControl {
 
                 disposed = true;
 
-                AsyncCancellationTokenSource?.Cancel();
+                try {
+                    AsyncCancellationTokenSource?.Cancel();
+                } catch (ObjectDisposedException) { }
+                
 
                 WebViewInitialized = null;
                 BeforeNavigate = null;


### PR DESCRIPTION
Fix tests pipeline blowup in a consumer project due to an ObjectDisposedException.

https://docs.microsoft.com/en-us/dotnet/api/system.threading.cancellationtokensource.cancel
