### PR TITLE
Fix CORS issue fetching stylesheet resources

### DIFF
--- a/WebViewControl.Avalonia/WebViewControl.Avalonia.csproj
+++ b/WebViewControl.Avalonia/WebViewControl.Avalonia.csproj
@@ -13,7 +13,7 @@
     <Copyright>Copyright ©  2019</Copyright>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>2.91.29</Version>
+    <Version>2.91.30</Version>
     <PackageId>WebViewControl-Avalonia</PackageId>
     <Authors>OutSystems</Authors>
     <PackageProjectUrl>https://github.com/OutSystems/WebView</PackageProjectUrl>

--- a/WebViewControl/HttpResourceHandler.cs
+++ b/WebViewControl/HttpResourceHandler.cs
@@ -14,7 +14,8 @@ namespace WebViewControl {
             // These resources types need an "Access-Control-Allow-Origin" header response entry
             // to comply with CORS security restrictions.
             CefResourceType.SubFrame,
-            CefResourceType.FontResource
+            CefResourceType.FontResource,
+            CefResourceType.Stylesheet
         };
 
         protected override RequestHandlingFashion ProcessRequestAsync(CefRequest request, CefCallback callback) {

--- a/WebViewControl/WebViewControl.csproj
+++ b/WebViewControl/WebViewControl.csproj
@@ -12,7 +12,7 @@
     <Copyright>Copyright ©  2019</Copyright>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>2.91.21</Version>
+    <Version>2.91.30</Version>
     <PackageId>WebViewControl-WPF</PackageId>
     <Authors>OutSystems</Authors>
     <PackageProjectUrl>https://github.com/OutSystems/WebView</PackageProjectUrl>

--- a/WebViewControl/WebViewControl.csproj
+++ b/WebViewControl/WebViewControl.csproj
@@ -12,7 +12,7 @@
     <Copyright>Copyright ©  2019</Copyright>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>2.91.20</Version>
+    <Version>2.91.21</Version>
     <PackageId>WebViewControl-WPF</PackageId>
     <Authors>OutSystems</Authors>
     <PackageProjectUrl>https://github.com/OutSystems/WebView</PackageProjectUrl>


### PR DESCRIPTION
Based on this feedback, we confirmed that there was a type missing for stylesheets in the `AcceptedResources` array of the `HttpResourceHandler`. 

This was causing a CORS error when loading external CSS resources, even when with the security is disabled (`OwnerWebView.IsSecurityDisabled = true`) - see also
https://github.com/OutSystems/WebView/blob/3738be5c4addedfce1167d02f29b26c08eefc43e/WebViewControl/WebView.InternalRequestHandler.cs#L95

With this change, the CORS error is suppressed.