### PR TITLE
Update mime type and status

### DIFF
--- a/WebViewControl.Avalonia/WebViewControl.Avalonia.csproj
+++ b/WebViewControl.Avalonia/WebViewControl.Avalonia.csproj
@@ -13,7 +13,7 @@
     <Copyright>Copyright ©  2019</Copyright>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>2.91.30</Version>
+    <Version>2.91.31</Version>
     <PackageId>WebViewControl-Avalonia</PackageId>
     <Authors>OutSystems</Authors>
     <PackageProjectUrl>https://github.com/OutSystems/WebView</PackageProjectUrl>

--- a/WebViewControl/HttpResourceHandler.cs
+++ b/WebViewControl/HttpResourceHandler.cs
@@ -9,7 +9,6 @@ namespace WebViewControl {
     internal class HttpResourceHandler : DefaultResourceHandler {
 
         private const string AccessControlAllowOriginHeaderKey = "Access-Control-Allow-Origin";
-        private const string ContentTypeHeaderKey = "Content-Type";
 
         internal static readonly CefResourceType[] AcceptedResources = new CefResourceType[] {
             // These resources types need an "Access-Control-Allow-Origin" header response entry
@@ -28,13 +27,9 @@ namespace WebViewControl {
                         httpRequest.Headers.Add(key, headers[key]);
                     }
 
-                    var response = (HttpWebResponse) await httpRequest.GetResponseAsync();
+                    var response = await httpRequest.GetResponseAsync();
                     Response = response.GetResponseStream();
                     Headers = response.Headers;
-
-                    this.MimeType = response.Headers[ContentTypeHeaderKey];
-                    this.Status = (int) response.StatusCode;
-                    this.StatusText = response.StatusDescription;
 
                     // we have to smash any existing value here
                     Headers.Remove(AccessControlAllowOriginHeaderKey);
@@ -47,7 +42,7 @@ namespace WebViewControl {
                 }
 
             });
-            return RequestHandlingFashion.ContinueAsync;
+            return RequestHandlingFashion.ContinueAsync;       
         }
 
         protected override bool Read(Stream outResponse, int bytesToRead, out int bytesRead, CefResourceReadCallback callback) {

--- a/WebViewControl/HttpResourceHandler.cs
+++ b/WebViewControl/HttpResourceHandler.cs
@@ -32,9 +32,9 @@ namespace WebViewControl {
                     Response = response.GetResponseStream();
                     Headers = response.Headers;
 
-                   MimeType = response.ContentType;
-                    this.Status = (int) response.StatusCode;
-                    this.StatusText = response.StatusDescription;
+                    MimeType = response.ContentType;
+                    Status = (int) response.StatusCode;
+                    StatusText = response.StatusDescription;
 
                     // we have to smash any existing value here
                     Headers.Remove(AccessControlAllowOriginHeaderKey);

--- a/WebViewControl/HttpResourceHandler.cs
+++ b/WebViewControl/HttpResourceHandler.cs
@@ -9,7 +9,6 @@ namespace WebViewControl {
     internal class HttpResourceHandler : DefaultResourceHandler {
 
         private const string AccessControlAllowOriginHeaderKey = "Access-Control-Allow-Origin";
-        private const string ContentTypeHeaderKey = "Content-Type";
 
         internal static readonly CefResourceType[] AcceptedResources = new CefResourceType[] {
             // These resources types need an "Access-Control-Allow-Origin" header response entry

--- a/WebViewControl/HttpResourceHandler.cs
+++ b/WebViewControl/HttpResourceHandler.cs
@@ -9,6 +9,7 @@ namespace WebViewControl {
     internal class HttpResourceHandler : DefaultResourceHandler {
 
         private const string AccessControlAllowOriginHeaderKey = "Access-Control-Allow-Origin";
+        private const string ContentTypeHeaderKey = "Content-Type";
 
         internal static readonly CefResourceType[] AcceptedResources = new CefResourceType[] {
             // These resources types need an "Access-Control-Allow-Origin" header response entry
@@ -27,9 +28,13 @@ namespace WebViewControl {
                         httpRequest.Headers.Add(key, headers[key]);
                     }
 
-                    var response = await httpRequest.GetResponseAsync();
+                    var response = (HttpWebResponse) await httpRequest.GetResponseAsync();
                     Response = response.GetResponseStream();
                     Headers = response.Headers;
+
+                    this.MimeType = response.Headers[ContentTypeHeaderKey];
+                    this.Status = (int) response.StatusCode;
+                    this.StatusText = response.StatusDescription;
 
                     // we have to smash any existing value here
                     Headers.Remove(AccessControlAllowOriginHeaderKey);
@@ -42,7 +47,7 @@ namespace WebViewControl {
                 }
 
             });
-            return RequestHandlingFashion.ContinueAsync;       
+            return RequestHandlingFashion.ContinueAsync;
         }
 
         protected override bool Read(Stream outResponse, int bytesToRead, out int bytesRead, CefResourceReadCallback callback) {

--- a/WebViewControl/HttpResourceHandler.cs
+++ b/WebViewControl/HttpResourceHandler.cs
@@ -32,7 +32,7 @@ namespace WebViewControl {
                     Response = response.GetResponseStream();
                     Headers = response.Headers;
 
-                    this.MimeType = response.Headers[ContentTypeHeaderKey];
+                   MimeType = response.ContentType;
                     this.Status = (int) response.StatusCode;
                     this.StatusText = response.StatusDescription;
 

--- a/WebViewControl/HttpResourceHandler.cs
+++ b/WebViewControl/HttpResourceHandler.cs
@@ -9,6 +9,7 @@ namespace WebViewControl {
     internal class HttpResourceHandler : DefaultResourceHandler {
 
         private const string AccessControlAllowOriginHeaderKey = "Access-Control-Allow-Origin";
+        private const string ContentTypeHeaderKey = "Content-Type";
 
         internal static readonly CefResourceType[] AcceptedResources = new CefResourceType[] {
             // These resources types need an "Access-Control-Allow-Origin" header response entry
@@ -27,9 +28,13 @@ namespace WebViewControl {
                         httpRequest.Headers.Add(key, headers[key]);
                     }
 
-                    var response = await httpRequest.GetResponseAsync();
+                    var response = (HttpWebResponse) await httpRequest.GetResponseAsync();
                     Response = response.GetResponseStream();
                     Headers = response.Headers;
+
+                    this.MimeType = response.Headers[ContentTypeHeaderKey];
+                    this.Status = (int) response.StatusCode;
+                    this.StatusText = response.StatusDescription;
 
                     // we have to smash any existing value here
                     Headers.Remove(AccessControlAllowOriginHeaderKey);

--- a/WebViewControl/WebViewControl.csproj
+++ b/WebViewControl/WebViewControl.csproj
@@ -12,7 +12,7 @@
     <Copyright>Copyright ©  2019</Copyright>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>2.91.30</Version>
+    <Version>2.91.31</Version>
     <PackageId>WebViewControl-WPF</PackageId>
     <Authors>OutSystems</Authors>
     <PackageProjectUrl>https://github.com/OutSystems/WebView</PackageProjectUrl>


### PR DESCRIPTION
The MimeType property in DefaultResourceHandler was never updated with the actual Mime Type so any request with HttpResourceHandler would than have the Content Type header changed to the default - text/html. This caused requested CSS to not be applied due to invalid Mime Type.
The same happened with the Status Code and Status Description.