### PR TITLE
Exposed cef flags

### DIFF
--- a/WebViewControl/GlobalSettings.cs
+++ b/WebViewControl/GlobalSettings.cs
@@ -16,11 +16,8 @@ namespace WebViewControl {
         private List<KeyValuePair<string, string>> commandLineSwitches = new();
 
         public void AddCommandLineSwitch(string key, string value) {
-            EnsureNotLoaded(nameof(flags));
-            if (flags == null) {
-                flags = new();
-            }
-            flags.Add(new KeyValuePair<string, string>(key, value));
+            EnsureNotLoaded(nameof(AddCommandLineSwitch));
+            commandLineSwitches.Add(new KeyValuePair<string, string>(key, value));
         }
         
         public IEnumerable<KeyValuePair<string, string>> CommandLineSwitches => commandLineSwitches;

--- a/WebViewControl/GlobalSettings.cs
+++ b/WebViewControl/GlobalSettings.cs
@@ -15,6 +15,9 @@ namespace WebViewControl {
         private string cachePath = Path.Combine(Path.GetTempPath(), "WebView" + Guid.NewGuid().ToString().Replace("-", null) + DateTime.UtcNow.Ticks);
         private List<KeyValuePair<string, string>> commandLineSwitches = new();
 
+        /// <summary>
+        /// Use this method to pass flags to the browser. List of available flags: https://peter.sh/experiments/chromium-command-line-switches/
+        /// </summary>
         public void AddCommandLineSwitch(string key, string value) {
             EnsureNotLoaded(nameof(AddCommandLineSwitch));
             commandLineSwitches.Add(new KeyValuePair<string, string>(key, value));

--- a/WebViewControl/GlobalSettings.cs
+++ b/WebViewControl/GlobalSettings.cs
@@ -13,7 +13,7 @@ namespace WebViewControl {
         private string userAgent;
         private string logFile;
         private string cachePath = Path.Combine(Path.GetTempPath(), "WebView" + Guid.NewGuid().ToString().Replace("-", null) + DateTime.UtcNow.Ticks);
-        private List<KeyValuePair<string, string>> flags;
+        private List<KeyValuePair<string, string>> commandLineSwitches = new();
 
         public void AddCommandLineSwitch(string key, string value) {
             EnsureNotLoaded(nameof(flags));

--- a/WebViewControl/GlobalSettings.cs
+++ b/WebViewControl/GlobalSettings.cs
@@ -22,9 +22,8 @@ namespace WebViewControl {
             }
             flags.Add(new KeyValuePair<string, string>(key, value));
         }
-        public KeyValuePair<string, string>[] GetCommandLineSwitches() {
-            return flags.ToArray();
-        }
+        
+        public IEnumerable<KeyValuePair<string, string>> CommandLineSwitches => commandLineSwitches;
 
         public string CachePath {
             get => cachePath;

--- a/WebViewControl/GlobalSettings.cs
+++ b/WebViewControl/GlobalSettings.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using Xilium.CefGlue.Common;
 
@@ -12,7 +13,15 @@ namespace WebViewControl {
         private string userAgent;
         private string logFile;
         private string cachePath = Path.Combine(Path.GetTempPath(), "WebView" + Guid.NewGuid().ToString().Replace("-", null) + DateTime.UtcNow.Ticks);
+        private Dictionary<string, string> flags;
 
+        public Dictionary<string, string> Flags {
+            get => flags;
+            set {
+                EnsureNotLoaded(nameof(Flags));
+                flags = value;
+            }
+        }
         public string CachePath {
             get => cachePath;
             set {

--- a/WebViewControl/GlobalSettings.cs
+++ b/WebViewControl/GlobalSettings.cs
@@ -13,7 +13,7 @@ namespace WebViewControl {
         private string userAgent;
         private string logFile;
         private string cachePath = Path.Combine(Path.GetTempPath(), "WebView" + Guid.NewGuid().ToString().Replace("-", null) + DateTime.UtcNow.Ticks);
-        private List<KeyValuePair<string, string>> commandLineSwitches = new();
+        private readonly List<KeyValuePair<string, string>> commandLineSwitches = new();
 
         /// <summary>
         /// Use this method to pass flags to the browser. List of available flags: https://peter.sh/experiments/chromium-command-line-switches/

--- a/WebViewControl/GlobalSettings.cs
+++ b/WebViewControl/GlobalSettings.cs
@@ -13,15 +13,19 @@ namespace WebViewControl {
         private string userAgent;
         private string logFile;
         private string cachePath = Path.Combine(Path.GetTempPath(), "WebView" + Guid.NewGuid().ToString().Replace("-", null) + DateTime.UtcNow.Ticks);
-        private Dictionary<string, string> flags;
+        private List<KeyValuePair<string, string>> flags;
 
-        public Dictionary<string, string> Flags {
-            get => flags;
-            set {
-                EnsureNotLoaded(nameof(Flags));
-                flags = value;
+        public void AddCommandLineSwitch(string key, string value) {
+            EnsureNotLoaded(nameof(flags));
+            if (flags == null) {
+                flags = new();
             }
+            flags.Add(new KeyValuePair<string, string>(key, value));
         }
+        public KeyValuePair<string, string>[] GetCommandLineSwitches() {
+            return flags.ToArray();
+        }
+
         public string CachePath {
             get => cachePath;
             set {

--- a/WebViewControl/WebViewLoader.cs
+++ b/WebViewControl/WebViewLoader.cs
@@ -47,7 +47,7 @@ namespace WebViewControl {
 
             settings.AddCommandLineSwitch("enable-experimental-web-platform-features", null);
 
-            CefRuntimeLoader.Initialize(settings: cefSettings, flags: settings.GetCommandLineSwitches(), customSchemes: customSchemes);
+            CefRuntimeLoader.Initialize(settings: cefSettings, flags: settings.CommandLineSwitches.ToArray(), customSchemes: customSchemes);
 
             AppDomain.CurrentDomain.ProcessExit += delegate { Cleanup(); };
         }

--- a/WebViewControl/WebViewLoader.cs
+++ b/WebViewControl/WebViewLoader.cs
@@ -38,20 +38,23 @@ namespace WebViewControl {
                 WindowlessRenderingEnabled = settings.OsrEnabled,
                 RemoteDebuggingPort = settings.GetRemoteDebuggingPort(),
                 UserAgent = settings.UserAgent
-             
+
             };
 
-            var customSchemes = CustomSchemes.Select(s => new CustomScheme() { 
-                SchemeName = s, 
+            var customSchemes = CustomSchemes.Select(s => new CustomScheme() {
+                SchemeName = s,
                 SchemeHandlerFactory = new SchemeHandlerFactory()
             }).ToArray();
 
-            var customFlags = new[] {
+            if (settings.Flags == null) {
+                settings.Flags = new();
+            }
+            if (!settings.Flags.ContainsKey("enable-experimental-web-platform-features")) {
                 // enable experimental feature flags
-                new KeyValuePair<string, string>("enable-experimental-web-platform-features", null)
-            };
+                settings.Flags.Add("enable-experimental-web-platform-features", null);
+            }
 
-            CefRuntimeLoader.Initialize(settings: cefSettings, flags: customFlags, customSchemes: customSchemes);
+            CefRuntimeLoader.Initialize(settings: cefSettings, flags: settings.Flags.ToArray(), customSchemes: customSchemes);
 
             AppDomain.CurrentDomain.ProcessExit += delegate { Cleanup(); };
         }

--- a/WebViewControl/WebViewLoader.cs
+++ b/WebViewControl/WebViewLoader.cs
@@ -46,15 +46,9 @@ namespace WebViewControl {
                 SchemeHandlerFactory = new SchemeHandlerFactory()
             }).ToArray();
 
-            if (settings.Flags == null) {
-                settings.Flags = new();
-            }
-            if (!settings.Flags.ContainsKey("enable-experimental-web-platform-features")) {
-                // enable experimental feature flags
-                settings.Flags.Add("enable-experimental-web-platform-features", null);
-            }
+            settings.AddCommandLineSwitch("enable-experimental-web-platform-features", null);
 
-            CefRuntimeLoader.Initialize(settings: cefSettings, flags: settings.Flags.ToArray(), customSchemes: customSchemes);
+            CefRuntimeLoader.Initialize(settings: cefSettings, flags: settings.GetCommandLineSwitches(), customSchemes: customSchemes);
 
             AppDomain.CurrentDomain.ProcessExit += delegate { Cleanup(); };
         }

--- a/WebViewControl/WebViewLoader.cs
+++ b/WebViewControl/WebViewLoader.cs
@@ -38,7 +38,6 @@ namespace WebViewControl {
                 WindowlessRenderingEnabled = settings.OsrEnabled,
                 RemoteDebuggingPort = settings.GetRemoteDebuggingPort(),
                 UserAgent = settings.UserAgent
-
             };
 
             var customSchemes = CustomSchemes.Select(s => new CustomScheme() {


### PR DESCRIPTION
Added `Flags` lookup dictionary to `GlobalSettings` while retaining default "enable-experimental-web-platform-features" in `WebViewLoader`.  

This allows command-line args to be passed to chromium. [Here ](https://peter.sh/experiments/chromium-command-line-switches/)is a list of most available flags and [here ](https://www.chromium.org/developers/how-tos/run-chromium-with-flags/) is more info about flags.