### PR TITLE
RDOIBT-2026 - access fonts from resources

### DIFF
--- a/WebViewControl/HttpResourceHandler.cs
+++ b/WebViewControl/HttpResourceHandler.cs
@@ -14,7 +14,6 @@ namespace WebViewControl {
             // These resources types need an "Access-Control-Allow-Origin" header response entry
             // to comply with CORS security restrictions.
             CefResourceType.SubFrame,
-            CefResourceType.FontResource,
             CefResourceType.Stylesheet
         };
 


### PR DESCRIPTION
In short, at the moment the font resources that are used in a theme (as example) are not being loaded in design time in IDE.
This will unblock the studio loading when developing the apps.

c.c @joaompneves what's your take on this? Do you know any possible side effect of this?