### PR TITLE
Add logging to webview

### DIFF
--- a/WebViewControl.Avalonia/WebView.Avalonia.cs
+++ b/WebViewControl.Avalonia/WebView.Avalonia.cs
@@ -57,7 +57,9 @@ namespace WebViewControl {
         protected override void InternalDispose() => Dispose();
 
         private void ForwardException(ExceptionDispatchInfo exceptionInfo) {
-            // TODO
+            OperationOccurred?.Invoke("Exception not forwarded"); // Review this TODO
+
+            // TODO forward exception
         }
 
         private T ExecuteInUI<T>(Func<T> action) {

--- a/WebViewControl/WebView.cs
+++ b/WebViewControl/WebView.cs
@@ -474,8 +474,6 @@ namespace WebViewControl {
                     if (this.IsMainFrame(frameName)) {
                         // when a new main frame in created, dispose all running executors -> since they should not be valid anymore
                         // all child iframes were gone
-
-                        OperationOccurred?.Invoke("Dispose JS Executors for main frame");
                         DisposeJavascriptExecutors(JsExecutors.Where(je => !je.Value.IsValid).Select(je => je.Key).ToArray());
                     }
 

--- a/WebViewControl/WebView.cs
+++ b/WebViewControl/WebView.cs
@@ -203,7 +203,7 @@ namespace WebViewControl {
                 TitleChanged = null;
                 UnhandledAsyncException = null;
                 JavascriptContextReleased = null;
-                //OperationOccurred = null;
+                OperationOccurred = null;
 
                 // dispose the js executors before the browser to prevent (the browser) from throwing cancellation exceptions
                 DisposeJavascriptExecutors();


### PR DESCRIPTION
I noticed a bug when we would dispose all JS executors when creating and quickly destroying an iframe.

When creating and destroying an iframe very quickly, an event for javascript context create is triggered in cef and handled in “OnJavascriptContextCreated“ - whose Frame name is unusually empty. When doing so without being very quick, the frame name ends up fill in in the form of “<!--dynamicFrameE717EE81FE3B40E320D3A8FEA29FFA59-->“

The event is handled in https://github.com/OutSystems/WebView/blob/master/WebViewControl/WebView.cs#L445

When destroying the frame, another event is triggered which is handled in “OnJavascriptContextReleased“ (https://github.com/OutSystems/WebView/blob/master/WebViewControl/WebView.cs#L478)

Being the name empty, which is consulted in https://github.com/OutSystems/WebView/blob/master/WebViewControl/WebView.cs#L484, we are disposing the JS executors for the main frame a couple line below.

The  extension method in turn checks whether the frame name empty or not (https://github.com/OutSystems/WebView/blob/master/WebViewControl/WebView.Extensions.cs#L20).

The bug is not 100% on the WebView side, but we want to add logging so we can better understand similar scenarios like this that would lead to an unresposive browser