### PR TITLE
RDEV-6978 Fix Crash with detaching of tab when proxy is enabled

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,7 +10,7 @@
   <PropertyGroup>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
     <FileVersion>2.0.0.0</FileVersion>
-    <Version>2.121.101</Version>
+    <Version>2.121.102</Version>
     <Authors>OutSystems</Authors>
     <Product>WebViewControl</Product>
     <Copyright>Copyright © OutSystems 2023</Copyright>

--- a/WebViewControl.Avalonia/WebView.Avalonia.cs
+++ b/WebViewControl.Avalonia/WebView.Avalonia.cs
@@ -92,7 +92,7 @@ namespace WebViewControl {
         /// <paramref name="isSystemEvent">True if is a system focus event, or false if is a navigation</paramref>
         /// </summary>
         protected virtual bool OnSetFocus(bool isSystemEvent) {
-            var focusedElement = TopLevel.GetTopLevel(this).FocusManager.GetFocusedElement();
+            var focusedElement = TopLevel.GetTopLevel(this)?.FocusManager.GetFocusedElement();
             return !(focusedElement == chromium || focusedElement == this);
         }
     }


### PR DESCRIPTION
Fix Crash with detaching of tab when proxy is enabled. 

The VisualRoot of dummy webview is null at the time the onSetFocus is called when the tab is detached to create a new AggregatorWindow.