### PR TITLE
Increase stack size in windows OS

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
     <TargetDotnetVersion>net8.0</TargetDotnetVersion>
     <Platforms>x64;ARM64</Platforms>
     <AvaloniaVersion>11.0.10</AvaloniaVersion>
-    <CefGlueVersion>120.6099.7</CefGlueVersion>
+    <CefGlueVersion>120.6099.207</CefGlueVersion>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Following https://github.com/chromiumembedded/cef/issues/3250 and https://bitbucket.org/chromiumembedded/cef/commits/85c53029bf07, this PR aims at increasing the cef stack size to 8 MiBs. To do so, we use the visual studio tool "editbin".

Similarly to https://github.com/cefsharp/CefSharp/blob/d0486b317967fe4a3eb00e783c26d93d2a00e594/CefSharp.BrowserSubprocess/CefSharp.BrowserSubprocess.netcore.csproj#L67, we want to run editbin after building to increase the stack size to 8 MiBs.

Differenly from the link above, I tried drying the code a bit and make it more readable.

Please refer to https://github.com/OutSystems/CefGlue/pull/172 for more details.