### PR TITLE
RDEV-8025 - Adapt to different order Avalonia events are triggered

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,7 +10,7 @@
   <PropertyGroup>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
     <FileVersion>2.0.0.0</FileVersion>
-    <Version>3.120.7</Version>
+    <Version>3.120.8</Version>
     <Authors>OutSystems</Authors>
     <Product>WebViewControl</Product>
     <Copyright>Copyright © OutSystems 2023</Copyright>

--- a/WebViewControl.Avalonia/BaseControl.cs
+++ b/WebViewControl.Avalonia/BaseControl.cs
@@ -1,32 +1,17 @@
-﻿using System;
-using Avalonia.Controls;
-using Avalonia.Interactivity;
+﻿using Avalonia.Controls;
 using Avalonia.LogicalTree;
 
 namespace WebViewControl {
-
     public abstract class BaseControl : Control {
-
         protected abstract void InternalDispose();
 
-        protected override void OnAttachedToLogicalTree(LogicalTreeAttachmentEventArgs e) {
-            if (e.Root is Window window) {
-                // need to subscribe the event this way because close gets called after all elements get detached
-                window.AddHandler(Window.WindowClosedEvent, (EventHandler<RoutedEventArgs>)OnHostWindowClosed);
-            }
-            base.OnAttachedToLogicalTree(e);
-        }
-
         protected override void OnDetachedFromLogicalTree(LogicalTreeAttachmentEventArgs e) {
-            if (e.Root is Window window) {
-                window.RemoveHandler(Window.WindowClosedEvent, (EventHandler<RoutedEventArgs>)OnHostWindowClosed);
-            }
             base.OnDetachedFromLogicalTree(e);
-        }
 
-        private void OnHostWindowClosed(object sender, RoutedEventArgs eventArgs) {
-            ((Window)sender).RemoveHandler(Window.WindowClosedEvent, (EventHandler<RoutedEventArgs>)OnHostWindowClosed);
-            InternalDispose();
+            if (e.Root is Window w && w.PlatformImpl is null) {
+                // Window was closed.
+                InternalDispose();
+            }
         }
     }
 }


### PR DESCRIPTION
An update: this is the PR which caused the change in behavior: https://github.com/AvaloniaUI/Avalonia/pull/17059

Previously, events were fired in this order:

1. WindowClosed
2. DetachedFromLogicalTree
3. Closed

After #17059, events are fired in this order:

1. DetachedFromLogicalTree
2. Closed
3. WindowClosed

As you can see, previously the `WindowClosed` attached event was raised before the window itself was notified that it's been closed. This itself doesn't make much sense, as logically the Closed event on the window should have finished before the attached WindowClosed event is raised, so from a logical point of view the new event ordering makes more sense. This does however cause the problem that you're seeing, where you were using that event to determine whether a control is being removed from the logical tree due to its window closing, or for some other reason.

This is just an update: I'll let you know when I have a decision about whether we want to revert to the old (subtly incorrect) ordering, or if we have a better way of doing this.

