### PR TITLE
Add BackgroundColor and VideoAutoplay to CefSettings

### DIFF
--- a/WebViewControl/GlobalSettings.cs
+++ b/WebViewControl/GlobalSettings.cs
@@ -11,6 +11,7 @@ namespace WebViewControl {
         private Color backgroundColor = Color.White;
         private bool persistCache;
         private bool enableErrorLogOnly;
+        private bool enableVideoAutoplay = false; 
         private bool osrEnabled = false;
         private string userAgent;
         private string logFile;
@@ -85,6 +86,19 @@ namespace WebViewControl {
             set {
                 EnsureNotLoaded(nameof(OsrEnabled));
                 osrEnabled = value;
+            }
+        }
+
+        /// <summary>
+        /// Set to true to enable video autoplay without requiring user interaction.
+        /// This allows muted videos with the autoplay attribute to play automatically.
+        /// Default is false for security and user experience considerations.
+        /// </summary>
+        public bool EnableVideoAutoplay {
+            get => enableVideoAutoplay;
+            set {
+                EnsureNotLoaded(nameof(EnableVideoAutoplay));
+                enableVideoAutoplay = value;
             }
         }
 

--- a/WebViewControl/GlobalSettings.cs
+++ b/WebViewControl/GlobalSettings.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.IO;
 using Xilium.CefGlue.Common;
 
@@ -7,6 +8,7 @@ namespace WebViewControl {
 
     public class GlobalSettings {
 
+        private Color backgroundColor = Color.White;
         private bool persistCache;
         private bool enableErrorLogOnly;
         private bool osrEnabled = false;
@@ -24,6 +26,14 @@ namespace WebViewControl {
         }
         
         public IEnumerable<KeyValuePair<string, string>> CommandLineSwitches => commandLineSwitches;
+
+        public Color BackgroundColor {
+            get => backgroundColor;
+            set {
+                EnsureNotLoaded(nameof(BackgroundColor));
+                backgroundColor = value;
+            }
+        }
 
         public string CachePath {
             get => cachePath;

--- a/WebViewControl/WebViewLoader.cs
+++ b/WebViewControl/WebViewLoader.cs
@@ -37,7 +37,8 @@ namespace WebViewControl {
                 CachePath = settings.CachePath, // enable cache for external resources to speedup loading
                 WindowlessRenderingEnabled = settings.OsrEnabled,
                 RemoteDebuggingPort = settings.GetRemoteDebuggingPort(),
-                UserAgent = settings.UserAgent
+                UserAgent = settings.UserAgent,
+                BackgroundColor = new CefColor((uint)settings.BackgroundColor.ToArgb())
             };
 
             var customSchemes = CustomSchemes.Select(s => new CustomScheme() {

--- a/WebViewControl/WebViewLoader.cs
+++ b/WebViewControl/WebViewLoader.cs
@@ -47,7 +47,11 @@ namespace WebViewControl {
             }).ToArray();
 
             settings.AddCommandLineSwitch("enable-experimental-web-platform-features", null);
-
+            
+            if (settings.EnableVideoAutoplay) {
+                settings.AddCommandLineSwitch("autoplay-policy", "no-user-gesture-required");
+            }
+            
             CefRuntimeLoader.Initialize(settings: cefSettings, flags: settings.CommandLineSwitches.ToArray(), customSchemes: customSchemes);
 
             AppDomain.CurrentDomain.ProcessExit += delegate { Cleanup(); };


### PR DESCRIPTION
### This PR adds 2 things:

#### 1. Allow for setting the background color of the webview using:

```
// Set cef background color
WebView.Settings.BackgroundColor = Color.Black; 
```
This should be useful for:
- Dark themed apps, so that the webview does not flash white while loading content
- Consistency, we will be able to set a background consistent with the content that will be loaded

#### 2. Allow setting the video autoplay behavior using:

```
// Set cef video autoplay behavior
WebView.Settings.EnableVideoAutoplay = true;
```
Which should resolve #397 